### PR TITLE
Feature: Add Height Offset to House Anchor 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -275,7 +275,7 @@ a.hsc-btn:active.hsc-btn-color {
 .hsc-anchor {
     display: block;
     position: relative;
-    top: -150px;
+    top: -70px;
     visibility: hidden;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -272,6 +272,14 @@ a.hsc-btn:active.hsc-btn-color {
     text-align: left!important;
 }
 
+.hsc-anchor {
+    display: block;
+    position: relative;
+    top: -150px;
+    visibility: hidden;
+}
+
+
 hr {
     border-width: 2px;
     width: 70%;

--- a/index.html
+++ b/index.html
@@ -765,7 +765,9 @@
                 <hr/>
 
                 <!-- Thriving Mushroom -->
-                <div id="thriving-mushroom" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="thriving-mushroom" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h3>Thriving Mushroom</h3>

--- a/index.html
+++ b/index.html
@@ -205,7 +205,9 @@
 
 
                 <!-- beacon house -->
-                <div id="Beacon House" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="beaconhouse" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>BEACON HOUSE</h2>
@@ -231,7 +233,9 @@
                 <hr/>
 
                 <!-- embassy -->
-                <div id="embassy" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="embassy" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>THE EMBASSY</h2>
@@ -271,7 +275,9 @@
 
 
                 <!-- radical reading room -->
-                <div id="radicalreadingroom" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="radicalreadingroom" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>THE RADICAL READING ROOM</h2>
@@ -305,7 +311,9 @@
 
 
                 <!-- template house -->
-                <div id="template" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="template" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>TEMPLATE HOUSE</h2>
@@ -346,7 +354,9 @@
 
 
                 <!-- kaleidoscope -->
-                <div id="kaleidoscope" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="kaleidoscope" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>KALEIDOSCOPE</h2>
@@ -375,7 +385,9 @@
                 <hr/>
 
                 <!-- chrysalis -->
-                <div id="chrysalis" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="chrysalis" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>CHRYSALIS</h2>
@@ -405,7 +417,9 @@
 
 
                 <!-- crest -->
-                <div id="crest" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="crest" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>CREST</h2>
@@ -439,7 +453,9 @@
                 <hr/>
 
                 <!-- rgb -->
-                <div id="rgb" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="rgb" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>RGB House</h2>
@@ -481,7 +497,9 @@
                 <hr/>
 
                 <!-- the center -->
-                <div id="center" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="center" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>The Center</h2>
@@ -514,7 +532,9 @@
                 <hr/>
 
                 <!-- manzanita -->
-                <div id="manzanita" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="manzanita" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>Manzanita</h2>
@@ -548,7 +568,9 @@
                 <hr/>
 
                 <!-- agape -->
-                <div id="agape" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="agape" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>Agape</h2>
@@ -577,7 +599,9 @@
                 <hr/>
 
                 <!-- sigil -->
-                <div id="sigil" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="sigil" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>Sigil House</h2>
@@ -600,7 +624,9 @@
                 <hr/>
 
                 <!-- real house -->
-                <div id="real" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="real" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>The Real House</h2>
@@ -622,7 +648,9 @@
                 <hr/>
 
                 <!-- grammys -->
-                <div id="grammys" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="grammys" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>Grammy's House</h2>
@@ -647,7 +675,9 @@
                 <hr/>
 
                 <!-- nuhaus -->
-                <div id="nuhaus" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="nuhaus" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>NuHaus</h2>
@@ -672,7 +702,9 @@
                 <hr/>
 
                 <!-- the village -->
-                <div id="the-village" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="the-village" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>The Village</h2>
@@ -699,7 +731,9 @@
                 <hr/>
 
                 <!-- Eucalyptus -->
-                <div id="eucalyptus" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="eucalyptus" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>Eucalyptus</h2>
@@ -722,7 +756,9 @@
                 <hr/>
 
                 <!-- the muse -->
-                <div id="the-muse" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="the-muse" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>The Muse</h2>
@@ -744,7 +780,9 @@
                 <hr/>
 
                 <!-- McAllister House -->
-                <div id="mcallister-house" class="col-sm-12 col-md-10 house-container">
+                <div class="col-sm-12 col-md-10 house-container">
+                    <div class="hsc-anchor" id="mcallister-house" ></div>
+
                     <div class="hsc-img-box col-xs-12 col-sm-6">
                         <div class="hsc-img-overlay">
                             <h2>McAllister House</h2>


### PR DESCRIPTION
When you click a house side-bar link this is what it looks like: 
<img width="761" alt="image" src="https://github.com/user-attachments/assets/6ff71ab0-7130-4cb4-91f6-955a8668e32e">

Now, when you click side-bar link the "anchor" is now offset up so that it now looks like this: 
<img width="731" alt="image" src="https://github.com/user-attachments/assets/fbb93d78-3f6c-4e69-9787-84782af0b1ca">
