### PR TITLE
minor style fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,10 @@ h1, h2, h3, h4, h5, h6 {
     width: 100%;
 }
 
+.house-container .row {
+    padding: 0px;
+}
+
 /* ==========
     BANNER
 ========== */
@@ -182,7 +186,7 @@ the houses section
     position: relative;
     text-align: left;
     z-index: -99;
-    max-width: 1400px;
+    max-width: 1200px;
     display: flex;
     flex-direction: column;
 
@@ -269,10 +273,13 @@ a.hsc-menu-item:active {
     background-color: #333;
     background-color: rgba(51, 51, 51, 0.6);
     color: #FCFCFC;
+    max-width: 100%;
 }
 
 .hsc-img-overlay h2 {
     font-size: 2.5em;
+    overflow-x: scroll;
+    overflow-y: clip;
 }
 
 .hsc-img-overlay img {


### PR DESCRIPTION
This PR adds some minor style fixes that are relevant for narrow screens (e.g. a Pixel 6). I removed some padding to use space more efficiently. Houses with very wide names (Kaleidscope) get cropped with a little scrollbar rather than pushing the entire content wide. Fwiw, this issue existed before my recent changes too but was less noticeable because there was no navbar on mobile.

# Before
<img width="621" alt="before" src="https://github.com/user-attachments/assets/2a172897-c5d3-4546-b48b-4b7a1d59966f">

# After
<img width="448" alt="after" src="https://github.com/user-attachments/assets/880c9b4b-f051-4ed2-b057-6dc9121883c6">
